### PR TITLE
Azure Sub Key Headers

### DIFF
--- a/src/routers/AppRouter.jsx
+++ b/src/routers/AppRouter.jsx
@@ -53,6 +53,9 @@ import EditService from "../pages/EditService";
 import CreateService from "../components/CreateService";
 import ServiceForm from "../components/ServiceForm";
 
+import axios from "axios";
+axios.defaults.headers.common['Ocp-Apim-Subscription-Key'] = import.meta.env.VITE_API_KEY;
+
 function ScrollToTop() {
   const location = useLocation();
 


### PR DESCRIPTION
set axios.defaults.header for azure subscription key in AppRouter so it is available globally